### PR TITLE
Sb data release

### DIFF
--- a/bispy/__init__.py
+++ b/bispy/__init__.py
@@ -15,6 +15,7 @@ from . import gap
 from . import iucn
 from . import sgcn
 from . import gbif
+from . import sb
 
 # provide version, PEP - three components ("major.minor.micro")
 __version__ = pkg_resources.require("bispy")[0].version

--- a/bispy/bis.py
+++ b/bispy/bis.py
@@ -6,36 +6,33 @@ import os
 import json
 from genson import SchemaBuilder
 import pkg_resources
-
+import sciencebasepy
 
 class Sciencebase:
     def __init__(self):
-        self.sb_catalog_items_api = "https://www.sciencebase.gov/catalog/items"
-
-    def collection_items(self, collectionid, fields="id"):
+        self.sbpy = sciencebasepy.SbSession()
+    
+    def collection_items(self, collection_id, fields="id"):
         '''
         Loops through specified ScienceBase collection to return all items in a list with a set of fields. This
         function handles the issue of looping through the ScienceBase pagination when you need to get more items than
-        the maximum that can be returned.
-
-        :param collectionid: ScienceBase parent item ID
-        :param fields: List of ScienceBase Item fields to return
-        :return: List of the ScienceBase Items within the GAP species
+        the maximum that can be returned. Note a max of 100,000 records can be returned using this method.
+        :param collectionid: str, ScienceBase parent item ID
+        :param fields: str, comma delimited string of ScienceBase Item fields to return
+        :return: List of the ScienceBase child items under parent item
         '''
-        nextlink = f"{self.sb_catalog_items_api}?max=100&parentId={collectionid}&format=json&fields={fields}"
+        filter = f"parentId={collection_id}" 
+        params = {"max":100, "filter":filter, "fields": fields}
 
         item_list = list()
+        
+        items = self.sbpy.find_items(params)
 
-        while nextlink is not None:
-            r = requests.get(nextlink).json()
-            item_list.extend(r["items"])
-            if "nextlink" in r.keys():
-                nextlink = r["nextlink"]["url"]
-            else:
-                nextlink = None
+        while items and 'items' in items:
+            item_list.extend(items['items'])
+            items = self.sbpy.next(items)
 
         return item_list
-
 
 class Utils:
     def __init__(self):

--- a/bispy/sb.py
+++ b/bispy/sb.py
@@ -1,0 +1,87 @@
+import sciencebasepy
+from . import bis
+
+bis_utils = bis.Utils()
+
+class Search:
+    def __init__(self):
+        self.sbpy = sciencebasepy.SbSession()
+        self.params = {}
+
+    #Could add param function to open up search a bit?
+    #def update_params(self, search_term, filter="", max=100, fields="id"):
+    #    self.params = {"q":search_term, "max":max, "filter":filter, "fields": fields}
+
+    def data_release_search(self, search_term, max="100", fields="id"):
+        '''
+        Searches for official ScienceBase data releases and returns json structure of search result.
+        This function handles the issue of looping through the ScienceBase pagination when you need to 
+        get more items than the maximum that can be returned.
+
+        :param search_term: search term that helps identify data release items of interest
+        :param fields: Comma delimited string of ScienceBase Item fields to return
+        :return: Data release items that are officially recognized by ScienceBase returned from search
+        '''
+        
+        filter_data_release = "systemType=Data Release" 
+        self.params = {"q":search_term, "max":"100", "filter":filter_data_release, "fields": fields}
+        result = self.search()
+        return result
+    
+    def in_progress_data_release_search(self, search_term, fields="id"):
+        '''
+        Searches for official ScienceBase data releases that are in progress and returns json structure of search result.
+        This function handles the issue of looping through the ScienceBase pagination when you need to 
+        get more items than the maximum that can be returned.
+
+        :param search_term: search term that helps identify data release items of interest
+        :param fields: Comma delimited string of ScienceBase Item fields to return
+        :return: Data release items that are officially recognized by ScienceBase returned from search
+        '''
+        
+        filter_data_release = "browseCategory=Data Release - In Progress" 
+        self.params = {"q":search_term, "max":100, "filter":filter_data_release, "fields": fields}
+        result = self.search()
+        return result
+
+    def search(self):
+        '''
+        Loops through ScienceBase data release items to return all items meeting specified params.  
+        This includes both official ScienceBase data releases and those in progress.
+        This function handles the issue of looping through the ScienceBase pagination when you need to 
+        get more items than the maximum that can be returned.
+
+        :param search_term: search term that helps identify data release items of interest
+        :param fields: Comma delimited string of ScienceBase Item fields to return
+        :return: Data release items that are officially recognized by ScienceBase returned from search
+        '''
+        item_list = []
+
+        result = bis_utils.processing_metadata()
+        result["processing_metadata"]["status"] = "failure"
+        result["processing_metadata"]["status_message"] = "Search failed"
+        
+        params = self.params
+        
+        try: 
+            items = self.sbpy.find_items(params)
+            result["processing_metadata"]["api"] = items['selflink']['url']
+            result["parameters"] = params
+            if len(items['items']) == 0:
+                result["processing_metadata"]["status"] = "success"
+                result["processing_metadata"]["status_message"] = "No official ScienceBase data realeases"
+                #Do we want to capture null returns as result['data']=[] or not include 
+                return result
+            else:
+                while items and 'items' in items:
+                    item_list.extend(items['items'])
+                    items = self.sbpy.next(items)
+                num_results = f'{len(item_list)} official ScienceBase data realeases'
+                result["processing_metadata"]["status"] = "success"
+                result["processing_metadata"]["status_message"] = num_results
+                result["data"] = item_list
+                return result
+
+        except:
+            result["processing_metadata"]["status"] = "failure"
+            return result

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='bispy',
-      version='0.0.6',
+      version='0.0.7',
       description='Essential logic for the Biogeographic Information System',
       url='http://github.com/usgs-bcb/bispy',
       author='R. Sky Bristol',
@@ -15,6 +15,7 @@ setup(name='bispy',
             'xmltodict',
             'geopandas',
             'owslib',
-            'genson'
+            'genson',
+            'sciencebasepy'
       ],
       zip_safe=False)


### PR DESCRIPTION
I took @dwief-usgs 's ideas in a somewhat different direction. The main things we need here are an implementation of ScienceBase search that incorporates our processing metadata to to create a snapshot of a result for a data release or some other cache of ScienceBase items and a little bit of help on building some of the interesting filters we need. When I looked at the full enumeration of values for both systemType and browseCategory, they include data release pointers but some other interesting items. I added a listing of potential values to the sciencebase.Search class and changed the function to allow for these values and set them up as numbered filters.

There are still some safeguards that we might want to add here to take care of potential issues. It's fully possible to blow things up with this function, request every item in ScienceBase, and try to build a massive list. But I think the basic pattern should work for now. Here's a simple test:

``
import bispy
sb_search = bispy.sciencebase.Search()
sb_search.search_snapshot(
    system_type="Data Release", 
    fields="title,body,files,webLinks", 
    q="Canis lupus"
)